### PR TITLE
refactor: replace any types with proper TS interfaces in MDX components

### DIFF
--- a/app/components/atelier/atelierMdx.tsx
+++ b/app/components/atelier/atelierMdx.tsx
@@ -9,7 +9,7 @@ const atelierComponents = {
   Meteor,
 };
 
-const AtelierMdx = ({ source }: any) => {
+const AtelierMdx = ({ source }: { source: string }) => {
   return (
     <article className="prose dark:prose-invert prose-h1:text-2xl prose-a:break-all max-w-2xl break-keep">
       <MDXRemote source={source} components={atelierComponents} />

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -7,8 +7,8 @@ import Typewriter from "./2024-gencon/typewriter";
 import GridMasonry from "./portfolio/GridMasonry";
 import { Callout } from "./callout";
 
-function CustomLink(props: any) {
-  const href = props.href;
+function CustomLink(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const href = props.href ?? "";
 
   if (href.startsWith("/")) {
     return (
@@ -25,13 +25,17 @@ function CustomLink(props: any) {
   return <a target="_blank" rel="noreferrer" {...props} />;
 }
 
-function CustomImage({ width, height, ...props }: any) {
+interface CustomImageProps extends Omit<React.ComponentProps<typeof Image>, 'width' | 'height'> {
+  width?: string | number;
+  height?: string | number;
+}
+
+function CustomImage({ width, height, ...props }: CustomImageProps) {
   const w = Number(width) || 768;
   const h = Number(height) || 400;
 
   return (
     <Image
-      alt={props.alt}
       width={w}
       height={h}
       {...props}
@@ -54,7 +58,12 @@ const options: Options = {
   theme: "poimandres",
 };
 
-export async function Mdx({ components, source }: any) {
+interface MdxProps {
+  components?: Record<string, React.ComponentType>;
+  source: string;
+}
+
+export async function Mdx({ components, source }: MdxProps) {
   "use cache";
 
   return (


### PR DESCRIPTION
## Summary
- Replace `any` types in `CustomLink`, `CustomImage`, `Mdx`, and `AtelierMdx` with proper TypeScript interfaces
- Add null-safe `href` handling in `CustomLink` using nullish coalescing
- Remove redundant explicit `alt` prop in `CustomImage` that was overwritten by the spread operator

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx next build` compiles successfully (pre-existing runtime error in unrelated `/music/playlists/[id]` page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)