### PR TITLE
refactor: centralize site URLs into SITE_URL constant

### DIFF
--- a/app/(main)/writing/[slug]/opengraph-image.tsx
+++ b/app/(main)/writing/[slug]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
 import { getAllWritings } from "@/lib/utils";
+import { SITE_URL } from "@/lib/constants";
 
 export const alt = "Yujiseok's Blog Post";
 export const size = {
@@ -53,7 +54,7 @@ export default async function Image({
         flexDirection: "column",
         alignItems: "flex-start",
         justifyContent: "center",
-        backgroundImage: "url(https://yujiseok.blog/og-bg.png)",
+        backgroundImage: `url(${SITE_URL}/og-bg.png)`,
       }}
     >
       <div

--- a/app/(main)/writing/[slug]/page.tsx
+++ b/app/(main)/writing/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { getAllWritings } from "@/lib/utils";
 import { Mdx } from "@/app/components/mdx";
 import BlurContainer from "@/app/components/blurContainer";
+import { SITE_URL } from "@/lib/constants";
 
 
 export function generateStaticParams() {
@@ -42,7 +43,7 @@ export async function generateMetadata(props: {
       description,
       type: "article",
       publishedTime,
-      url: `https://www.yujiseok.blog/writing/${writing.slug}`,
+      url: `${SITE_URL}/writing/${writing.slug}`,
     },
     twitter: {
       card: "summary_large_image",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { Suspense } from "react";
 import Footer from "@/app/components/footer";
 import Lenis from "./components/lenis";
+import { SITE_URL } from "@/lib/constants";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -16,13 +17,13 @@ const geistSans = Geist({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://www.yujiseok.blog"),
+  metadataBase: new URL(SITE_URL),
   title: "Yujiseok",
   description: "공부하는 것을 기록하고 공유하는 유지석의 개인 기술 블로그",
   openGraph: {
     title: "유지석",
     description: "공부하는 것을 기록하고 공유하는 유지석의 개인 기술 블로그",
-    url: "https://www.yujiseok.blog/",
+    url: `${SITE_URL}/`,
     locale: "ko_KR",
     type: "website",
     siteName: "유지석",

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { SITE_URL } from "@/lib/constants";
 
 export const alt = "Yujiseok's Blog";
 export const size = {
@@ -17,7 +18,7 @@ export default async function Image() {
         flexDirection: "column",
         alignItems: "flex-start",
         justifyContent: "center",
-        backgroundImage: "url(https://yujiseok.blog/og-bg.png)",
+        backgroundImage: `url(${SITE_URL}/og-bg.png)`,
       }}
     >
       <div

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,6 +1,7 @@
 import ArrowUpRight from "@/app/components/arrowUpRight";
 import BlurContainer from "@/app/components/blurContainer";
 import { resumeData } from "./resume";
+import { SITE_URL } from "@/lib/constants";
 
 export const metadata = {
   title: `${resumeData.profile.name} | ${resumeData.profile.title}`,
@@ -23,14 +24,14 @@ export const metadata = {
     address: false,
     telephone: false,
   },
-  metadataBase: new URL("https://yujiseok.blog"),
+  metadataBase: new URL(SITE_URL),
   alternates: {
     canonical: "/resume",
   },
   openGraph: {
     title: `${resumeData.profile.name} | ${resumeData.profile.title}`,
     description: resumeData.profile.introduction[0],
-    url: "https://yujiseok.blog/resume",
+    url: `${SITE_URL}/resume`,
     siteName: "유지석 블로그",
     locale: "ko_KR",
     type: "profile",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/constants";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -6,7 +7,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://www.yujiseok.blog/sitemap.xml",
-    host: "https://www.yujiseok.blog",
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,8 @@
 import { getAllWritings } from "@/lib/utils";
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/constants";
 
-export const baseURL = "https://www.yujiseok.blog";
+export const baseURL = SITE_URL;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const writings = getAllWritings().map((writing) => ({

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = "https://www.yujiseok.blog";


### PR DESCRIPTION
## Summary
- Create `lib/constants.ts` with `SITE_URL = "https://www.yujiseok.blog"`
- Replace all hardcoded site URLs across 7 files with the `SITE_URL` constant
- Standardize on `https://www.yujiseok.blog` (with www) everywhere — previously `app/resume/page.tsx` and OG image files used the non-www variant

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx next build` — pre-existing error in `/music/playlists/[id]` unrelated to these changes; TypeScript compilation succeeds
- [ ] Verify OG images render correctly in production
- [ ] Verify sitemap.xml and robots.txt output correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)