### PR TITLE
refactor: extract resume page components

### DIFF
--- a/app/resume/components/ContentContainer.tsx
+++ b/app/resume/components/ContentContainer.tsx
@@ -1,0 +1,21 @@
+const ContentContainer = ({
+  title,
+  children,
+}: {
+  title:
+    | "Work Experience"
+    | "Open Source Contribution"
+    | "Education"
+    | "Other Experience"
+    | "Contact";
+  children: React.ReactNode;
+}) => {
+  return (
+    <div className="grid gap-4 sm:gap-6">
+      <h3 className="font-semibold text-base">{title}</h3>
+      <div className="grid gap-4">{children}</div>
+    </div>
+  );
+};
+
+export default ContentContainer;

--- a/app/resume/components/ResumeContent.tsx
+++ b/app/resume/components/ResumeContent.tsx
@@ -1,0 +1,18 @@
+const ResumeContent = ({
+  rightContent,
+  leftContent,
+}: {
+  rightContent: React.ReactNode;
+  leftContent: React.ReactNode;
+}) => {
+  return (
+    <div className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-10">
+      <div className="text-neutral-600 dark:text-neutral-400">
+        {leftContent}
+      </div>
+      <div>{rightContent}</div>
+    </div>
+  );
+};
+
+export default ResumeContent;

--- a/app/resume/components/ResumeProfile.tsx
+++ b/app/resume/components/ResumeProfile.tsx
@@ -1,0 +1,27 @@
+const ResumeProfile = ({
+  profile,
+}: {
+  profile: {
+    name: string;
+    title: string;
+    introduction: readonly string[];
+  };
+}) => {
+  return (
+    <div className="grid gap-8">
+      <div>
+        <h1 className="text-xl font-semibold">{profile.name}</h1>
+        <small className="text-xs text-neutral-600 dark:text-neutral-400">
+          {profile.title}
+        </small>
+      </div>
+      <div className="grid gap-2">
+        {profile.introduction.map((paragraph) => (
+          <p key={paragraph}>{paragraph}</p>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ResumeProfile;

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,6 +1,9 @@
 import ArrowUpRight from "@/app/components/arrowUpRight";
 import BlurContainer from "@/app/components/blurContainer";
 import { resumeData } from "./resume";
+import ResumeProfile from "./components/ResumeProfile";
+import ResumeContent from "./components/ResumeContent";
+import ContentContainer from "./components/ContentContainer";
 
 export const metadata = {
   title: `${resumeData.profile.name} | ${resumeData.profile.title}`,
@@ -278,67 +281,3 @@ const page = () => {
 };
 
 export default page;
-
-const ResumeProfile = ({
-  profile,
-}: {
-  profile: {
-    name: string;
-    title: string;
-    introduction: readonly string[];
-  };
-}) => {
-  return (
-    <div className="grid gap-8">
-      <div>
-        <h1 className="text-xl font-semibold">{profile.name}</h1>
-        <small className="text-xs text-neutral-600 dark:text-neutral-400">
-          {profile.title}
-        </small>
-      </div>
-
-      <div className="grid gap-2">
-        {profile.introduction.map((paragraph) => (
-          <p key={paragraph}>{paragraph}</p>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-const ResumeContent = ({
-  rightContent,
-  leftContent,
-}: {
-  rightContent: React.ReactNode;
-  leftContent: React.ReactNode;
-}) => {
-  return (
-    <div className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-10">
-      <div className="text-neutral-600 dark:text-neutral-400">
-        {leftContent}
-      </div>
-      <div>{rightContent}</div>
-    </div>
-  );
-};
-
-const ContentContainer = ({
-  title,
-  children,
-}: {
-  title:
-  | "Work Experience"
-  | "Open Source Contribution"
-  | "Education"
-  | "Other Experience"
-  | "Contact";
-  children: React.ReactNode;
-}) => {
-  return (
-    <div className="grid gap-4 sm:gap-6">
-      <h3 className="font-semibold text-base">{title}</h3>
-      <div className="grid gap-4">{children}</div>
-    </div>
-  );
-};


### PR DESCRIPTION
## Summary
- Extracted `ResumeProfile`, `ResumeContent`, and `ContentContainer` from `app/resume/page.tsx` into separate files under `app/resume/components/`
- Reduces `page.tsx` from 344 lines to ~283 lines by removing inline component definitions
- No behavioral changes; all components remain Server Components with identical props and rendering

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Next.js build compiles successfully (pre-existing unrelated error in `/music/playlists/[id]`)
- [ ] Visual check: resume page renders identically before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)