### PR TITLE
refactor: extract duplicated getWritingBySlug into shared utility

### DIFF
--- a/app/(main)/writing/[slug]/opengraph-image.tsx
+++ b/app/(main)/writing/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { getAllWritings } from "@/lib/utils";
+import { getWritingBySlug } from "@/lib/utils";
 
 export const alt = "Yujiseok's Blog Post";
 export const size = {
@@ -7,11 +7,6 @@ export const size = {
   height: 1080,
 };
 export const contentType = "image/png";
-
-const getWritingBySlug = (slug: string) => {
-  const writings = getAllWritings();
-  return writings.find((writing) => writing.slug === slug);
-};
 
 export default async function Image({
   params,

--- a/app/(main)/writing/[slug]/page.tsx
+++ b/app/(main)/writing/[slug]/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
 
-import { getAllWritings } from "@/lib/utils";
+import { getAllWritings, getWritingBySlug } from "@/lib/utils";
 import { Mdx } from "@/app/components/mdx";
 import BlurContainer from "@/app/components/blurContainer";
-
 
 export function generateStaticParams() {
   const writings = getAllWritings();
@@ -12,11 +11,6 @@ export function generateStaticParams() {
     slug: writing.slug,
   }));
 }
-
-const getWritingBySlug = (slug: string) => {
-  const writings = getAllWritings();
-  return writings.find((writing) => writing.slug === slug);
-};
 
 export async function generateMetadata(props: {
   params: Promise<{ slug: string }>;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -58,4 +58,10 @@ const getAllContent = (contentType: ContentType) => {
 };
 
 export const getAllWritings = () => getAllContent("writing");
+
+export const getWritingBySlug = (slug: string) => {
+  const writings = getAllWritings();
+  return writings.find((writing) => writing.slug === slug);
+};
+
 export const getAllAtelier = () => getAllContent("atelier");


### PR DESCRIPTION
## Summary
- Moved the duplicated `getWritingBySlug` function from `app/(main)/writing/[slug]/page.tsx` and `app/(main)/writing/[slug]/opengraph-image.tsx` into `lib/utils.ts`
- Both consumer files now import `getWritingBySlug` from `@/lib/utils` instead of defining it locally
- No behavioral changes; pure deduplication refactor

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Build failure is pre-existing and unrelated (music playlists page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)